### PR TITLE
parse outboundcid content into cid_num and cid_name sccpline fields

### DIFF
--- a/conf/Sccp.class.php.v433
+++ b/conf/Sccp.class.php.v433
@@ -1,7 +1,7 @@
 <?php
 // vim: set ai ts=4 sw=4 ft=php:
 // Version for SCCP Manager 13.0.X
-// 
+//
 //   Templete for Sccp Driver
 //
 namespace FreePBX\modules\Core\Drivers;
@@ -11,10 +11,11 @@ class Sccp extends \FreePBX\modules\Core\Driver {
                                  "callgroup"=>'callgroup',"pickupgroup"=>'pickupgroup',
                                  "transfer" => 'transfer', "echocancel" => 'echocancel',
                                  "language" => 'language', "description" => 'callerid',
-                                 "cid_num" => 'cid_num', "cid_name" => 'label', "mailbox" => 'description',
-                                 "musicclass" => 'musicclass',
+                                 "cid_num" => 'cid_num', "cid_name" => 'cid_name', "mailbox" => 'mailbox',
+                                 "musicclass" => 'musicclass',"allow" => 'allow',"disallow" => 'disallow',
+                                 "videomode" => 'videomode',
                                  "dnd" => 'dnd', "silencesuppression" => 'silencesuppression',
-                                 "secondary_dialtone_digits" => 'secondary_dialtone_digits', "secondary_dialtone_tone" => 'secondary_dialtone_tone',            
+                                 "secondary_dialtone_digits" => 'secondary_dialtone_digits', "secondary_dialtone_tone" => 'secondary_dialtone_tone',
                                  'namedcallgroup'=>'namedcallgroup', 'namedpickupgroup' => 'namedpickupgroup'
                             );
 
@@ -27,7 +28,7 @@ class Sccp extends \FreePBX\modules\Core\Driver {
 			"description" => _("Sccp Device"),
 			"Version" => "11.4",
 			"about" => "Sccp mysql class Base ver: 11.3, Sccp ver: default"
-                    
+
 		);
 	}
 
@@ -46,7 +47,10 @@ class Sccp extends \FreePBX\modules\Core\Driver {
 //                print_r($_REQUEST);
 //                echo '<br><br>';
 //                die(print_r($settings));
-                $settings['cid_num']['value']='';
+                $settings['cid_num']['value'] = '';
+                $settings['cid_name']['value'] = $label;
+                $settings['mailbox']['value']= '';
+
                 if (isset($_REQUEST)){
                     foreach($add_fld as $key => $val) {
                         if (!empty($_REQUEST[$key])){
@@ -54,10 +58,43 @@ class Sccp extends \FreePBX\modules\Core\Driver {
                         }
                     }
                 }
-                if (empty($settings['cid_num']['value'])) {
-                    $settings['cid_num']['value']= $id;
+                $allow_codec = array();
+                foreach($settings as $key => $val) {
+                    if (strpos($key,'codec_') !== false ) {
+                         $allow_codec[] =substr($key,6);
+                    }
                 }
-                $sql = 'INSERT INTO sccpline (name';
+                $settings['allow']['value'] = implode(",", $allow_codec);
+
+		// parse outboundcid content into cid_num and cid_name sccpline fields
+                if (empty($settings['cid_num']['value'])) {
+                    $settings['cid_num']['value'] = $id;
+                } else {
+                    $outboundcid = $settings['cid_num']['value'];
+                    if (preg_match('/"(.*)"\s?<(.*)>/', $outboundcid, $matches)) {
+                        $settings['cid_num']['value'] = $matches[2];
+                        $settings['cid_name']['value'] = $matches[1];
+                    } else if (is_integer($outboundcid)) {
+                        $settings['cid_num']['value'] = $outboundcid;
+                    }
+                }
+
+                if (!empty($_REQUEST['vm']) && ($_REQUEST['vm'] =='enabled')){ // mailbox
+                    if (empty($settings['mailbox']['value'])) {
+                        $settings['mailbox']['value']= $id;
+                    }
+                }
+
+//                die(print_r($settings));
+                $tech = Array();
+                $sql = "DESCRIBE `sccpline`";
+                foreach ($this->database->query($sql) as $row) {
+                    $tech[$row["Field"]]=$row["Field"];
+                }
+
+//                die(print_r($tech));
+
+                $sql = 'REPLACE INTO sccpline (name';
                 $sqlv = 'values ("'.$id.'"';
 		foreach($this->data_fld as $key => $val) {
                     if (!empty($settings[$val]) ) {
@@ -67,7 +104,7 @@ class Sccp extends \FreePBX\modules\Core\Driver {
                         }
                     }
                 }
-                $sql .= ") ".$sqlv.");";              
+                $sql .= ") ".$sqlv.");";
 		$sth = $this->database->prepare($sql);
                 $sth->execute();
 		return true;
@@ -80,7 +117,7 @@ class Sccp extends \FreePBX\modules\Core\Driver {
 		return true;
 	}
 
-        
+
 	public function getDevice($id) {
                 $sccp_line = array();
 //		$sql = "SELECT name as id, name as name";
@@ -179,24 +216,24 @@ class Sccp extends \FreePBX\modules\Core\Driver {
 		$tmparr = array();
 		$tt = _("The maximum number of incoming calls on this line.");
 //		$tmparr['incominglimit'] = array('prompttext' => _('Incoming Call Limit'), 'value' => '2', 'tt' => $tt, 'level' => 0, 'jsvalidation' => 'isEmpty()', 'failvalidationmsg' => $msgInvalidChannel);
-// !TODO!: Please change the default value for incominglimit to '6' or higher 
+// !TODO!: Please change the default value for incominglimit to '6' or higher
 		$tmparr['incominglimit'] = array('prompttext' => _('Incoming Call Limit'), 'value' => '2', 'tt' => $tt, 'level' => 1);
 
                 $tt = _("Asterisk context which this line will use to send and receive calls (Note: Only change this is you know what you are doing).");
 		$tmparr['lcontext'] = array('prompttext' => _('Line context'), 'value' => 'from-internal', 'tt' => $tt, 'level' => 1);
 
-// !TODO!: -TODO-: Maybe completely remove support for old numberic callgroup/pickupgroup in favor of the named version ?  See Sccp.class.php.v431 
+// !TODO!: -TODO-: Maybe completely remove support for old numberic callgroup/pickupgroup in favor of the named version ?  See Sccp.class.php.v431
                 $tt = _("Phone call group (numeric only, example:1,3-4)");
 		$tmparr['callgroup'] = array('prompttext' => _('Call group id'),'value' => '', 'tt' => $tt, 'level' => 1);
 
-// !TODO!: -TODO-: multiple allowed (not sure if that is implemented here). See Sccp.class.php.v431 
+// !TODO!: -TODO-: multiple allowed (not sure if that is implemented here). See Sccp.class.php.v431
                 $tt = _("Phone named call group (>asterisk-11)");
 		$tmparr['namedcallgroup'] = array('prompttext' => _('Named Call Group'),'value' => '', 'tt' => $tt, 'level' => 1);
 
                 $tt = _("Sets the pickup group (numeric only, example:1,3-4) this line is a member of. Allows this line to pickup calls from remote phones which are in this callhroup.");
                 $tmparr['pickupgroup'] = array('prompttext' => _('Pickup group id'),'value' => '', 'tt' => $tt, 'level' => 1);
 
-// !TODO!: -TODO-: multiple allowed (not sure if that is implemented here). See Sccp.class.php.v431 
+// !TODO!: -TODO-: multiple allowed (not sure if that is implemented here). See Sccp.class.php.v431
                 $tt = _("Sets the named pickup name group this line is a member of. Allows this line to pickup calls from remote phones which are in this name callgroup (>asterisk-11).");
 		$tmparr['namedpickupgroup'] = array('prompttext' => _('Named Pickup Group'),'value' => '', 'tt' => $tt, 'level' => 1);
 
@@ -286,7 +323,7 @@ class Sccp extends \FreePBX\modules\Core\Driver {
                 $select[] = array('value' => 'silent', 'text' => 'Silent');
                 $select[] = array('value' => 'UserDefined', 'text' => 'UserDefined');
 # !TODO!: -TODO-: The next entry should be "null/empty" (not UserDefined) -> to indicate the trie-state behaviour
-# !TODO!: -TODO-: Userdefined is also a possible state, but it is not used or implemented (and it should not be implemented here, i think). See Sccp.class.php.v431, See Sccp.class.php - Old Style 
+# !TODO!: -TODO-: Userdefined is also a possible state, but it is not used or implemented (and it should not be implemented here, i think). See Sccp.class.php.v431, See Sccp.class.php - Old Style
                 $tt = _("DND: How will dnd react when it is set on the device level dnd can have three states: off / busy(reject) / silent / UserDefined").'<br>'.
                       _("UserDefined - dnd that cycles through all three states off -> reject -> silent -> off (this is the normal behaviour)").'<br>'.
                       _("Reject - Usesr can only switch off and on (in reject/busy mode)").'<br>'.
@@ -303,7 +340,7 @@ class Sccp extends \FreePBX\modules\Core\Driver {
                 $select[] = array('value' => 'default', 'text' => _('default'));
                 if (function_exists('music_list')){
                     $moh_list = music_list();
-                } else { 
+                } else {
                     $moh_list  = array('default');
                 }
                 foreach ($moh_list as $value) {
@@ -312,7 +349,7 @@ class Sccp extends \FreePBX\modules\Core\Driver {
 
                 $tt = _("Music on hold");
                 $tmparr['musicclass'] = array('prompttext' => _('Music on hold'), 'value' => 'no', 'tt' => $tt, 'select' => $select, 'level' => 1);
-                
+
 		$devopts = $tmparr;
 		return $devopts;
 	}


### PR DESCRIPTION
If outboundcid contains '"name" <num>' the content needs to be split to cid_name and cid_num.
If not the content should be a number and should be copied to cid_num only, in that case we fill cid_name with the value of $label

Fixes: #72

Signed-off-by: Diederik de Groot <dkgroot@talon.nl>