### PR TITLE
Change DB Spec for compatibility with older MariaDB

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -125,7 +125,7 @@
 			 <field name="ref" type="string" length="15" default="" primarykey="true"/>
 			 <field name="reftype" type="string" length="15" default="sccpdevice" primarykey="true"/>
 			 <field name="instance" type="boolean" default="0" primarykey="true"/>
-			 <field name="buttontype" type="string" length="255" default="line" primarykey="true"/>
+			 <field name="buttontype" type="string" length="190" default="line" primarykey="true"/>
 			 <field name="name" type="string" length="36" notnull="false"/>
 			 <field name="options" type="string" length="100" notnull="false"/>
 			 <key name="ref" type="index">


### PR DESCRIPTION
Close #12 

Older versions of MariaDB, which are included in some distros, reject a VARCHAR that is a key and can be NULL longer than 190 (Director default is 255)

Change for backward compatibility