### PR TITLE
Tftp detection

### DIFF
--- a/install.php
+++ b/install.php
@@ -1,4 +1,4 @@
-AS<?php
+<?php
 
 if (!defined('FREEPBX_IS_AUTH')) {
     die_freepbx('No direct script access allowed');
@@ -887,32 +887,46 @@ function checkTftpServer() {
     global $extconfigs;
     global $thisInstaller;
     $confDir = $cnf_int->get('ASTETCDIR');
-    // TODO: add option to use external server
-    $remoteFile = "TestFileXXX111.txt";  // should not exist
-    $thisInstaller->tftp_put_test_file();
+    $tftpRootPath = "";
 
+    // TODO: add option to use external server
+    $remoteFileName = ".sccp_manager_installer_probe_sentinel_temp".mt_rand(0, 9999999);
+    $remoteFileContent = "# This is a test file created by Sccp_Manager. It can be deleted without impact";
     $possibleFtpDirs = array('/srv', '/srv/tftp','/var/lib/tftp', '/tftpboot');
+    
+    // write a couple of sentinels to different distro tftp locations in the filesystem
     foreach ($possibleFtpDirs as $dirToTest) {
-        if (file_exists("{$dirToTest}/{$remoteFile}")) {
-            $tftpRootPath = $dirToTest;
-            unlink("{$dirToTest}/{$remoteFile}");
-            outn("<li>" . _("Found ftp root dir at {$dirToTest}") . "</li>");
-            if ($settingsFromDb['tftp_path']['data'] != $tftpRootPath) {
-                $settingsToDb["tftp_path"] =array( 'keyword' => 'tftp_path', 'seq' => 2, 'type' => 0, 'data' => $tftpRootPath);
-                // Need to set the new value here to pass to extconfigs below
-                $settingsFromDb['tftp_path']['data'] = $tftpRootPath;
+        if (is_dir($dirToTest) && is_writable($dirToTest) && empty($tftpRootPath)) {
+            $tempFile = "${dirToTest}/{$remoteFileName}";
+            $FH = fopen($tempFile, "w");
+            if ($FH == null) {
+                continue;
             }
-            break;
+            fwrite($FH, $remoteFileContent);
+            fclose($FH);
+
+            // try to pull the written file through tftp.
+            // this way we can determine if tftp server is active, and what it's 
+            // source directory is.
+            if ($remoteFileContent == $thisInstaller->tftpReadTestFile($remoteFileName)) {
+                $tftpRootPath = $dirToTest;
+                outn("<li>" . _("Found ftp root dir at {$tftpRootPath}") . "</li>");
+                if ($settingsFromDb['tftp_path']['data'] != $tftpRootPath) {
+                    $settingsToDb["tftp_path"] = array( 'keyword' => 'tftp_path', 'seq' => 2, 'type' => 0, 'data' => $tftpRootPath);
+                    // Need to set the new value here to pass to extconfigs below
+                    $settingsFromDb['tftp_path']['data'] = $tftpRootPath;
+                }
+            }
+            // remove all sentinel file
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
         }
     }
-
     if (empty($tftpRootPath)) {
         die_freepbx(_("Either TFTP server is down or TFTP root is non standard. Please fix, refresh, and try again"));
     }
-    if (!is_writeable($tftpRootPath)) {
-        die_freepbx(_("{$tftpRootPath} is not writable by user asterisk. Please fix, refresh and try again"));
-    }
-
+    
     $settingsToDb['asterisk_etc_path'] =array( 'keyword' => 'asterisk_etc_path', 'seq' => 20, 'type' => 0, 'data' => $confDir);
 
     foreach ($settingsToDb as $settingToSave) {
@@ -933,7 +947,6 @@ function checkTftpServer() {
             die_freepbx(_("Error updating sccpsettings. $sql"));
         }
     }
-
     return;
 }
 

--- a/install.php
+++ b/install.php
@@ -898,12 +898,7 @@ function checkTftpServer() {
     foreach ($possibleFtpDirs as $dirToTest) {
         if (is_dir($dirToTest) && is_writable($dirToTest) && empty($tftpRootPath)) {
             $tempFile = "${dirToTest}/{$remoteFileName}";
-            $FH = fopen($tempFile, "w");
-            if ($FH == null) {
-                continue;
-            }
-            fwrite($FH, $remoteFileContent);
-            fclose($FH);
+            file_put_contents($tempFile, $remoteFileContent);
 
             // try to pull the written file through tftp.
             // this way we can determine if tftp server is active, and what it's 

--- a/sccpManClasses/extconfigs.class.php
+++ b/sccpManClasses/extconfigs.class.php
@@ -326,8 +326,8 @@ class extconfigs
             $base_config[$key] = $adv_config[$value];
             // Save to sccpsettings
             $settingsToDb[$key] =array( 'keyword' => $key, 'seq' => 20, 'type' => 0, 'data' => $adv_config[$value]);
-            if (!file_exists($base_config[$key])) {
-                if (!mkdir($base_config[$key], 0777, true)) {
+            if (!is_dir($base_config[$key])) {
+                if (!mkdir($base_config[$key], 0755, true)) {
                     die_freepbx(_('Error creating dir : ' . $base_config[$key]));
                 }
             }

--- a/sccpManTraits/helperFunctions.php
+++ b/sccpManTraits/helperFunctions.php
@@ -182,10 +182,15 @@ trait helperfunctions {
             $numbytes = socket_recvfrom($socket, $buffer, 84, MSG_WAITALL, $host, $port);
             
             // unpack the returned buffer and discard the first two bytes
-            $pkt = unpack("n2/a*data", $buffer);
+            $pkt = unpack("nopcode/nblockno/a*data", $buffer);
+            
+            // send ack
+            $packet = chr(4) . chr(pkt["blockno"]);
+            socket_sendto($socket, $packet, strlen($packet), MSG_EOR, $host, $port);
 
             socket_close($socket);
-            if ($numbytes) {
+
+            if ($pkt["opcode"] == 3 && $numbytes) {
                 return $pkt["data"];
             }
         }


### PR DESCRIPTION
Reverse the logic when detecting tftpserver existence and path
 - write a sentinel probe file to the known/possible distro tftp directories
 - try fetching it through tftp
 - if we manage to fetch the file, we have the correct path
 - remove sentinel probe file

sccpManClasses/extconfigs.class.php : When creating directories in tftpboot directory we should not set write permissions, using 0755 instead.
