### PR TITLE
Fix writing settings to sccp.conf

### DIFF
--- a/Sccp_manager.class.php
+++ b/Sccp_manager.class.php
@@ -1002,67 +1002,6 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
         return $filename;
     }
 
-    function createDefaultSccpConfig() {
-        // Make sccp.conf data
-        // [general]
-        foreach ($this->sccpvalues as $key => $value) {
-            if ($value['seq'] == 0) {
-                switch ($key) {
-                    case "allow":
-                    case "disallow":
-                    case "deny":
-                        $this->sccp_conf_init['general'][$key] = explode(';', $value['data']);
-                        break;
-                    case "localnet":
-                    case "permit":
-                        $content = $value['data'];
-                        if (strpos($content, 'internal') !== false) {
-                            $content = str_replace(';0.0.0.0/0.0.0.0', '', $value['data']);
-                        }
-                        $this->sccp_conf_init['general'][$key] = explode(';', $content);
-                        break;
-                    case "devlang":
-                        /*
-                        $lang_data = $this->extconfigs->getExtConfig('sccp_lang', $value['data']);
-                        if (!empty($lang_data)) {
-                            // TODO:  will always get here, but lang_data['codepage'] will be empty as not a valid key
-                            $this->sccp_conf_init['general']['phonecodepage'] = $lang_data['codepage'];
-                        }
-                        break;
-                        */
-                    case "netlang": // Remove Key
-                    case "tftp_path":
-                    case "sccp_compatible":    // This is equal to SccpDBmodel
-                        break;
-                    default:
-                        if (!empty($value['data'])) {
-                            $this->sccp_conf_init['general'][$key] = $value['data'];
-                        }
-                }
-            }
-        }
-        // [Namesoftkeyset]
-        // type=softkeyset
-        //
-        // ----- It is a very bad idea to add an external configuration file "sccp_custom.conf" !!!!
-        // This will add problems when solving problems caused by unexpected solutions from users.
-        //
-        if (file_exists($this->sccppath["asterisk"] . "/sccp_custom.conf")) {
-            $this->sccp_conf_init['HEADER'] = array(
-                ";                                                                                ;",
-                ";  It is a very bad idea to add an external configuration file !!!!              ;",
-                ";  This will add problems when solving problems caused by unexpected solutions   ;",
-                ";  from users.                                                                   ;",
-                ";--------------------------------------------------------------------------------;",
-                "#include sccp_custom.conf"
-            );
-        }
-        // ----- It is a very bad idea to add an external configuration file "sccp_custom.conf" !!!!
-        // TODO: Should only rewrite the general section - if users have extensions, this may overwrite
-        // Should read first and then rewrite all existing sections.
-        $this->cnf_wr->writeConfig('sccp.conf', $this->sccp_conf_init);
-    }
-
     function getSccpModelInformation($get = "all", $validate = false, $format_list = "all", $filter = array()) {
         $file_ext = array('.loads', '.sbn', '.bin', '.zup', '.sbin', '.SBN', '.LOADS');
         $dir = $this->sccppath['tftp_firmware_path'];

--- a/conf/sccp.conf
+++ b/conf/sccp.conf
@@ -41,10 +41,3 @@ hotline_context=default
 hotline_extension=111
 devicetable=sccpdevice
 linetable=sccpline
-
-[KeySet1]	; Managed by sccp_manager
-type=softkeyset
-onhook=redial,newcall,cfwdall,dnd,pickup,gpickup,private
-connected=hold,endcall,park,select,cfwdall,cfwdbusy
-onhold=newcall
-

--- a/module.xml
+++ b/module.xml
@@ -1,7 +1,7 @@
 <module>
 	<rawname>sccp_manager</rawname>
 	<name>SCCP Manager</name>
-	<version>14.3.0.19</version>
+	<version>14.3.0.20</version>
 	<type>setup</type>
 	<category>SCCP Connectivity</category>
 	<publisher>Steve Lad, Alex GP</publisher>

--- a/sccpManClasses/Sccp.class.php.v433
+++ b/sccpManClasses/Sccp.class.php.v433
@@ -218,7 +218,6 @@ class Sccp extends \FreePBX\modules\Core\Driver {
     public function getDefaultDeviceSettings($id, $displayname, &$flag) {
         // FreePBX required method
         $settings = array();
-        dbug($this->line_defaults);
         $settingsFields = array('mailbox', 'incominglimit', 'context', 'directed_pickup_context', 'callgroup', 'pickupgroup', 'namedcallgroup',
                             'namedpickupgroup', 'adhocNumber', 'secondary_dialtone_digits', 'secondary_dialtone_tone', 'directed_pickup', 'pickup_modeanswer',
                             'transfer', 'echocancel', 'dnd', 'silencesuppression', 'musicclass', 'pin', 'allow', 'disallow');

--- a/sccpManTraits/ajaxHelper.php
+++ b/sccpManTraits/ajaxHelper.php
@@ -247,7 +247,7 @@ trait ajaxHelper {
                 if (!empty($request['softkey'])) {
                     $id_name = $request['softkey'];
                     unset($this->sccp_conf_init[$id_name]);
-                    $this->createDefaultSccpConfig();
+                    $this->createDefaultSccpConfig($this->sccpvalues, $this->sccppath["asterisk"]);
                     $msg = print_r($this->aminterface->core_sccp_reload(), 1);
                     return array('status' => true, 'table_reload' => true);
                 }
@@ -261,7 +261,7 @@ trait ajaxHelper {
                             $this->sccp_conf_init[$id_name][$keyl] = $request[$keyl];
                         }
                     }
-                    $this->createDefaultSccpConfig();
+                    $this->createDefaultSccpConfig($this->sccpvalues, $this->sccppath["asterisk"]);
 
                     // !TODO!: -TODO-:  Check SIP Support Enabled
                     $this->createSccpXmlSoftkey();
@@ -516,8 +516,8 @@ trait ajaxHelper {
         foreach ($dbSaveArray as $key => $rowToSave) {
             $this->dbinterface->updateTableDefaults($rowToSave['table'], $rowToSave['field'], $rowToSave['Default']);
         }
-
-        $this->createDefaultSccpConfig(); // Rewrite Config.
+        // rewrite sccp.conf
+        $this->createDefaultSccpConfig($this->sccpvalues, $this->sccppath["asterisk"]);
         $save_settings[] = array('status' => true, );
         $this->createDefaultSccpXml();
 


### PR DESCRIPTION
Only write chan-sccp allowed settings to sccp.conf
Clean sccp.conf on install
Move createDefaultSccpConfig to traits so that can access from installer
tighten calls to createDefaultSccpConfig