### PR TITLE
Only Save Config Differences Back to DB

### DIFF
--- a/Sccp_manager.class.php
+++ b/Sccp_manager.class.php
@@ -95,6 +95,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
     private $cnf_wr = null;
     public $sccppath = array();
     public $sccpvalues = array();
+    private $dbsccpvalues = array();
     public $sccp_conf_init = array();
     public $xml_data;
     public $class_error; //error construct
@@ -136,6 +137,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
         }
 
         $this->sccpvalues = $this->dbinterface->get_db_SccpSetting(); //Initialise core settings
+        $this->dbsccpvalues = $this->sccpvalues; //Copy settings from DB for future reference
         $this->initializeSccpPath();  //Set required Paths
         $this->updateTimeZone();   // Get timezone from FreePBX
         //$this->findInstLangs();
@@ -800,9 +802,9 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
      */
 
     private function saveSccpSettings($save_value = array()) {
-
+        $diffToSave = array_udiff_assoc($this->sccpvalues, $this->dbsccpvalues, array($this, "compareArrays"));
         if (empty($save_value)) {
-            $this->dbinterface->write('sccpsettings', $this->sccpvalues, 'replace'); //Change to replace as clearer
+            $this->dbinterface->write('sccpsettings', $diffToSave, 'update');
         } else {
             $this->dbinterface->write('sccpsettings', $save_value, 'update');
         }

--- a/sccpManTraits/helperFunctions.php
+++ b/sccpManTraits/helperFunctions.php
@@ -288,7 +288,13 @@ trait helperfunctions {
         return $sccp_conf_init;
     }
 
-
+    public function compareArrays(array $a, array $b){
+        if (array_diff_assoc($a, $b)===[]) {
+          return 0;
+          }
+          return ($a>$b)?1:-1;
+    }
+    
     public function checkTftpMapping(){
         exec('in.tftpd -V', $tftpInfo);
         $info['TFTP Server'] = array('Version' => 'Not Found', 'about' => 'Mapping not available');


### PR DESCRIPTION
The SCCP Phone Manager page was taking over 12 seconds (on very old hardware) to load for me (with ~15 phones configured). After some profiling, I saw sccp_manager was truncating the sccpsettings table on *every* pageload, then inserting the exact same settings back into the database. This was severely hurting my ability to configure phones in a timely manner.

It seems there are many ways to optimize sccp_manager to reduce page load time. I focused on only saving the difference of sccpvalues in order to achieve around 6x speedup. Now when loading SCCP Phone Manager page, sccpsettings will not be truncated. Instead settings will be updated by row as needed.

Please let me know if you would like me ot refactor, rename, comment, or test this some more. I was able to change phone and line settings, as well as server config settings with the new code. 